### PR TITLE
refactor: Use consistent naming for Lagon API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: lagonapp/github-action@latest
         with:
-          lagon_token: ${{ secrets.LAGON_API_TOKEN }}
+          lagon_token: ${{ secrets.LAGON_TOKEN }}
       - name: Log Function URL
         run: |
           url=$(grep -o 'https://[^[:space:]]*' lagon.output)
@@ -41,7 +41,7 @@ If you want to run a different command just specify it with the `command` input:
 
 ```bash
         with:
-          lagon_token: ${{ secrets.LAGON_API_TOKEN }}
+          lagon_token: ${{ secrets.LAGON_TOKEN }}
           command: ls
 ```
 
@@ -64,7 +64,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 
 ```bash
         with:
-          lagon_token: ${{ secrets.LAGON_API_TOKEN }}
+          lagon_token: ${{ secrets.LAGON_TOKEN }}
           config: |
             {
               "function_id": "${{ vars.lagon_function_id }}",

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
       run: |
         echo "Configuring Lagon CLI..."
         if [[ -z "${LAGON_TOKEN}" ]]; then
-            echo "LAGON_API_TOKEN input is not set"
+            echo "LAGON_TOKEN input is not set"
             exit 1
         fi
 


### PR DESCRIPTION
I figured, if the error gets logged it will be confusing to see `LAGON_API_TOKEN` not set when the action does not use this as input key.. it uses `lagon_token`.

Make sure to create another tagged release so the marketplace contains this new version. We can figure out automated releases later but I don't see us deploying changes much if ever again.